### PR TITLE
Fix static assertion over incorrect types

### DIFF
--- a/lib/stl_hashtable.h
+++ b/lib/stl_hashtable.h
@@ -17,7 +17,7 @@
 namespace vmp {
 
 template <class V, class MA = MemAlloc,
-    class PA = std::allocator<std::pair<String, V>>>
+    class PA = std::allocator<std::pair<const String, V>>>
 class StlHashtable : public StringHashtable<V> {
  public:
   typedef typename StringHashtable<V>::KVPair KVPair;


### PR DESCRIPTION
The assertion from issue 5 is caused from `const String` not being the same as `String`. `const String` is used as the value type, but not for the allocator.