### PR TITLE
add zeropadding parameter

### DIFF
--- a/core/core_workload.cc
+++ b/core/core_workload.cc
@@ -57,6 +57,9 @@ const string CoreWorkload::REQUEST_DISTRIBUTION_PROPERTY =
     "requestdistribution";
 const string CoreWorkload::REQUEST_DISTRIBUTION_DEFAULT = "uniform";
 
+const string CoreWorkload::ZERO_PADDING_PROPERTY = "zeropadding";
+const string CoreWorkload::ZERO_PADDING_DEFAULT = "1";
+
 const string CoreWorkload::MAX_SCAN_LENGTH_PROPERTY = "maxscanlength";
 const string CoreWorkload::MAX_SCAN_LENGTH_DEFAULT = "1000";
 
@@ -94,6 +97,7 @@ void CoreWorkload::Init(const utils::Properties &p) {
   record_count_ = std::stoi(p.GetProperty(RECORD_COUNT_PROPERTY));
   std::string request_dist = p.GetProperty(REQUEST_DISTRIBUTION_PROPERTY,
                                            REQUEST_DISTRIBUTION_DEFAULT);
+  zero_padding_ = std::stoi(p.GetProperty(ZERO_PADDING_PROPERTY, ZERO_PADDING_DEFAULT));
   int max_scan_len = std::stoi(p.GetProperty(MAX_SCAN_LENGTH_PROPERTY,
                                              MAX_SCAN_LENGTH_DEFAULT));
   std::string scan_len_dist = p.GetProperty(SCAN_LENGTH_DISTRIBUTION_PROPERTY,

--- a/core/core_workload.h
+++ b/core/core_workload.h
@@ -107,6 +107,13 @@ class CoreWorkload {
   static const std::string REQUEST_DISTRIBUTION_PROPERTY;
   static const std::string REQUEST_DISTRIBUTION_DEFAULT;
   
+  ///
+  /// The name of the property for adding zero padding to record numbers in order to match 
+  /// string sort order. Controls the number of 0s to left pad with.
+  ///
+  static const std::string ZERO_PADDING_PROPERTY;
+  static const std::string ZERO_PADDING_DEFAULT;
+
   /// 
   /// The name of the property for the max scan length (number of records).
   ///
@@ -184,6 +191,7 @@ class CoreWorkload {
   CounterGenerator insert_key_sequence_;
   bool ordered_inserts_;
   size_t record_count_;
+  int zero_padding_;
 };
 
 inline std::string CoreWorkload::NextSequenceKey() {
@@ -203,7 +211,10 @@ inline std::string CoreWorkload::BuildKeyName(uint64_t key_num) {
   if (!ordered_inserts_) {
     key_num = utils::Hash(key_num);
   }
-  return std::string("user").append(std::to_string(key_num));
+  std::string key_num_str = std::to_string(key_num);
+  int zeros = zero_padding_ - key_num_str.length();
+  zeros = std::max(0, zeros);
+  return std::string("user").append(zeros, '0').append(key_num_str);
 }
 
 inline std::string CoreWorkload::NextFieldName() {


### PR DESCRIPTION
add zeropadding parameter for specifying the number of 0s to left pad the key number, which can keep key length constant when ordered inserting.
Useful when using string sort order.

see [YCSB #674](https://github.com/brianfrankcooper/YCSB/pull/674/commits/c39e96d2c292db944ebcead14563a4eb5eb6a077)
and [YCSB wiki](https://github.com/brianfrankcooper/YCSB/wiki/Core-Properties)